### PR TITLE
Implement once

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! Using [`windows_mut`](crate::ToLendingIterator::windows_mut) on a range, mutating it and mapping it:
 //! ```
 //! use gat_lending_iterator::{LendingIterator, ToLendingIterator};
-//! 
+//!
 //! for sum in (0..7).windows_mut(2).map(|slice: &mut [usize]| {
 //!     slice[1] += slice[0];
 //!     slice[1]
@@ -83,9 +83,11 @@
 #![warn(clippy::pedantic)]
 
 mod adapters;
+mod sources;
 mod to_lending;
 mod traits;
 pub use self::adapters::*;
+pub use self::sources::*;
 pub use self::to_lending::*;
 pub use self::traits::*;
 
@@ -119,5 +121,12 @@ mod tests {
         for n in (0..5).windows(3).map(second).cloned() {
             println!("{n}");
         }
+    }
+
+    #[test]
+    fn test_once() {
+        let mut one = crate::once(1);
+        assert_eq!(Some(&1), one.next());
+        assert_eq!(None, one.next());
     }
 }

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,0 +1,2 @@
+mod once;
+pub use self::once::{once, Once};

--- a/src/sources/once.rs
+++ b/src/sources/once.rs
@@ -1,0 +1,29 @@
+use crate::LendingIterator;
+
+/// Creates an iterator that lends an element exactly once.
+pub fn once<T>(value: T) -> Once<T> {
+    Once {
+        done: false,
+        item: Some(value),
+    }
+}
+
+/// An iterator that lends an element exactly once.
+///
+/// This `struct` is created by the [`once()`] function. See its documentation for more.
+pub struct Once<T> {
+    done: bool,
+    item: Option<T>,
+}
+
+impl<T> LendingIterator for Once<T> {
+    type Item<'a> = &'a T where T: 'a;
+    fn next(&mut self) -> Option<Self::Item<'_>> {
+        if self.done {
+            self.item = None;
+        } else {
+            self.done = true;
+        }
+        self.item.as_ref()
+    }
+}


### PR DESCRIPTION
Took a stab at implementing once, I didn't think too hard, but off hand didn't see any cleverness that could be used to get rid of the additional field over the usual `iter::Once`.  I noticed `size_hint` isn't a part of the trait while implementing this, but is mentioned in the README. The std implementation overrides the default, because it isn't part of the trait yet I didn't add it.
Let me know if I should do so, either as part of this or as a follow up.