### PR TITLE
add `into_lending_refs` and `into_lending_refs_mut`

### DIFF
--- a/src/to_lending/lend_refs.rs
+++ b/src/to_lending/lend_refs.rs
@@ -1,0 +1,55 @@
+use crate::LendingIterator;
+
+/// A lending iterator that given an iterator, lends
+/// references to the given iterator's items.
+pub struct LendRefs<I: Iterator> {
+    item: Option<I::Item>,
+    iter: I,
+}
+
+impl<I: Iterator> LendRefs<I> {
+    pub(crate) fn new(iter: I) -> LendRefs<I> {
+        LendRefs { item: None, iter }
+    }
+}
+
+impl<I> LendingIterator for LendRefs<I>
+where
+    I: Iterator,
+{
+    type Item<'a> = &'a I::Item where Self: 'a;
+
+    fn next(&mut self) -> Option<Self::Item<'_>> {
+        self.item = self.iter.next();
+        self.item.as_ref()
+    }
+}
+#[cfg(test)]
+mod test {
+    use crate::{LendingIterator, ToLendingIterator};
+    #[derive(Clone, Eq, PartialEq, Debug)]
+    struct Foo(usize);
+    struct W {
+        x: Foo,
+    }
+    impl LendingIterator for W {
+        type Item<'a> = &'a Foo where Self: 'a;
+        fn next(&mut self) -> Option<Self::Item<'_>> {
+            self.x.0 += 1;
+            Some(&self.x)
+        }
+    }
+    #[test]
+    fn test() {
+        let mut xs = Vec::new();
+        test_helper().take(3).for_each(|x: &Foo| {
+            xs.push(x.clone());
+        });
+        assert_eq!(xs, vec![Foo(0), Foo(1), Foo(2)]);
+    }
+
+    fn test_helper() -> impl for<'a> LendingIterator<Item<'a> = &'a Foo> {
+        let w = W { x: Foo(0) };
+        std::iter::once(Foo(0)).lend_refs().chain(w)
+    }
+}

--- a/src/to_lending/lend_refs_mut.rs
+++ b/src/to_lending/lend_refs_mut.rs
@@ -1,0 +1,56 @@
+use crate::LendingIterator;
+
+/// A lending iterator that given an iterator, lends
+/// mutable references to the given iterator's items.
+pub struct LendRefsMut<I: Iterator> {
+    item: Option<I::Item>,
+    iter: I,
+}
+
+impl<I: Iterator> LendRefsMut<I> {
+    pub(crate) fn new(iter: I) -> LendRefsMut<I> {
+        LendRefsMut { item: None, iter }
+    }
+}
+
+impl<I: Iterator> LendingIterator for LendRefsMut<I> {
+    type Item<'a> = &'a mut I::Item where Self: 'a;
+
+    fn next(&mut self) -> Option<Self::Item<'_>> {
+        self.item = self.iter.next();
+        self.item.as_mut()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{LendingIterator, ToLendingIterator};
+    #[derive(Clone, Eq, PartialEq, Debug)]
+    struct Foo(usize);
+    struct W {
+        x: Foo,
+    }
+
+    impl LendingIterator for W {
+        type Item<'a> = &'a mut Foo where Self: 'a;
+        fn next(&mut self) -> Option<Self::Item<'_>> {
+            self.x.0 += 1;
+            Some(&mut self.x)
+        }
+    }
+
+    #[test]
+    fn test() {
+        let mut xs = Vec::new();
+        test_helper().take(3).for_each(|x: &mut Foo| {
+            x.0 += 2;
+            xs.push(x.clone());
+        });
+        assert_eq!(xs, vec![Foo(2), Foo(3), Foo(6)]);
+    }
+
+    fn test_helper() -> impl for<'a> LendingIterator<Item<'a> = &'a mut Foo> {
+        let w = W { x: Foo(0) };
+        std::iter::once(Foo(0)).lend_refs_mut().chain(w)
+    }
+}

--- a/src/to_lending/mod.rs
+++ b/src/to_lending/mod.rs
@@ -1,6 +1,10 @@
 mod into_lending;
+mod lend_refs;
+mod lend_refs_mut;
 mod windows;
 mod windows_mut;
 pub use self::into_lending::IntoLending;
+pub use self::lend_refs::LendRefs;
+pub use self::lend_refs_mut::LendRefsMut;
 pub use self::windows::Windows;
 pub use self::windows_mut::WindowsMut;

--- a/src/traits/to_lending_iterator.rs
+++ b/src/traits/to_lending_iterator.rs
@@ -1,4 +1,4 @@
-use crate::{IntoLending, Windows, WindowsMut};
+use crate::{IntoLending, LendRefs, LendRefsMut, Windows, WindowsMut};
 
 /// An extension trait for iterators that allows turning them into lending iterators (over windows of elements).
 pub trait ToLendingIterator: IntoIterator {
@@ -34,6 +34,24 @@ pub trait ToLendingIterator: IntoIterator {
         Self: Sized,
     {
         IntoLending::new(self.into_iter())
+    }
+
+    /// Turns this iterator into a lending iterator that lends references
+    /// to the iterator's items.
+    fn lend_refs(self) -> LendRefs<Self::IntoIter>
+    where
+        Self: Sized,
+    {
+        LendRefs::new(self.into_iter())
+    }
+
+    /// Turns this iterator into a lending iterator that lends mutable references
+    /// to the iterator's items.
+    fn lend_refs_mut(self) -> LendRefsMut<Self::IntoIter>
+    where
+        Self: Sized,
+    {
+        LendRefsMut::new(self.into_iter())
     }
 }
 


### PR DESCRIPTION
Here is a first stab at an abstraction similar to the one we discussed in #14.
I wasn't able to figure out a way to implement it exactly as you had mentioned.
In there you had mentioned it being a method on `LendingIterator`, which is where I ran into problems.
So for the time being these both take a `Iterator` instead and subsequently lend references, and mut references respectively to the iterator's item.

The issue I ran into implementing it on `LendingIterator` is as follows, in order to hold an `Item<'i>` we end up bringing the lifetime up into the struct, so far so good.

```
pub struct LendingRefs<'i, I>
where
   I: LendingIterator + 'i,
{
    item: Option<I::Item<'i>>,
    iter: I,
}
```

But once it comes time to implement the `LendingIterator` trait, I couldn't figure out a way to implement the trait, such that it both lives long enough, and also matches the trait.  Because we end up having to bind the lifetimes to the self and returned item.

I think the names I'd chosen `into_lending_refs` and `into_lending_refs_mut` are a bit long and verbose.
So I'm not all that partial to them, but I do find them clear.

If you have any ideas on how to implement it for `LendingIterator` instead, I'd be happy to keep trying but I myself ran out of ideas there.

Edit: One idea to try and work around this lifetime error is leveraging `MaybeUninit`, will try that tomorrow.