### PR TITLE
make crate no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ categories = ["algorithms", "rust-patterns"]
 rust-version = "1.65"
 
 [features]
-default = []
+default = ["alloc"]
 alloc = []
 std = ["alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ readme = "README.md"
 keywords = ["iterator", "lending", "gat"]
 categories = ["algorithms", "rust-patterns"]
 rust-version = "1.65"
+
+[features]
+default = []
+alloc = []
+std = ["alloc"]

--- a/src/adapters/cloned.rs
+++ b/src/adapters/cloned.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use core::ops::Deref;
 
 use crate::LendingIterator;
 

--- a/src/adapters/enumerate.rs
+++ b/src/adapters/enumerate.rs
@@ -71,9 +71,9 @@ mod test {
     fn test() {
         let first = Some((0, ()));
         let second = Some((1, ()));
-        let mut delay_iter = Delay::new(1, std::iter::repeat(()).take(2)).enumerate();
+        let mut delay_iter = Delay::new(1, core::iter::repeat(()).take(2)).enumerate();
         let mut delay_lending =
-            Delay::new(1, std::iter::repeat(()).into_lending().take(2)).enumerate();
+            Delay::new(1, core::iter::repeat(()).into_lending().take(2)).enumerate();
 
         assert_eq!((None, None), (delay_iter.next(), delay_lending.next()));
         assert_eq!((first, first), (delay_iter.next(), delay_lending.next()));

--- a/src/adapters/take.rs
+++ b/src/adapters/take.rs
@@ -40,7 +40,7 @@ mod test {
     #[test]
     fn test() {
         assert_eq!(
-            std::iter::repeat(())
+            core::iter::repeat(())
                 .into_lending()
                 .take(5)
                 .fold(0, |count, ()| { count + 1 }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,12 @@
 //! 3
 //! ```
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 #![warn(clippy::pedantic)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 mod adapters;
 mod to_lending;
@@ -93,11 +97,18 @@ pub use self::traits::*;
 mod tests {
     use super::*;
 
+    #[cfg(not(feature = "std"))]
+    #[test]
+    fn std_feature_is_enabled() -> Result<(), &'static str> {
+        Err("The `std` feature is required to run all tests, try `cargo test --features std`")
+    }
+
     fn second(slice: &[usize]) -> &usize {
         &slice[1]
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn playground() {
         (0..5)
             .windows(3)

--- a/src/to_lending/lend_refs.rs
+++ b/src/to_lending/lend_refs.rs
@@ -41,6 +41,7 @@ mod test {
         }
     }
     #[test]
+    #[cfg(feature = "std")]
     fn test() {
         let mut xs = Vec::new();
         test_helper().take(3).for_each(|x: &Foo| {
@@ -51,6 +52,6 @@ mod test {
 
     fn test_helper() -> impl for<'a> LendingIterator<Item<'a> = &'a Foo> {
         let w = W { x: Foo(0) };
-        std::iter::once(Foo(0)).lend_refs().chain(w)
+        core::iter::once(Foo(0)).lend_refs().chain(w)
     }
 }

--- a/src/to_lending/lend_refs_mut.rs
+++ b/src/to_lending/lend_refs_mut.rs
@@ -41,6 +41,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test() {
         let mut xs = Vec::new();
         test_helper().take(3).for_each(|x: &mut Foo| {
@@ -52,6 +53,6 @@ mod test {
 
     fn test_helper() -> impl for<'a> LendingIterator<Item<'a> = &'a mut Foo> {
         let w = W { x: Foo(0) };
-        std::iter::once(Foo(0)).lend_refs_mut().chain(w)
+        core::iter::once(Foo(0)).lend_refs_mut().chain(w)
     }
 }

--- a/src/to_lending/mod.rs
+++ b/src/to_lending/mod.rs
@@ -1,10 +1,14 @@
 mod into_lending;
 mod lend_refs;
 mod lend_refs_mut;
+#[cfg(feature = "alloc")]
 mod windows;
+#[cfg(feature = "alloc")]
 mod windows_mut;
 pub use self::into_lending::IntoLending;
 pub use self::lend_refs::LendRefs;
 pub use self::lend_refs_mut::LendRefsMut;
+#[cfg(feature = "alloc")]
 pub use self::windows::Windows;
+#[cfg(feature = "alloc")]
 pub use self::windows_mut::WindowsMut;

--- a/src/to_lending/windows.rs
+++ b/src/to_lending/windows.rs
@@ -1,4 +1,5 @@
 use crate::LendingIterator;
+use alloc::vec::Vec;
 
 /// A lending iterator over windows.
 ///

--- a/src/to_lending/windows_mut.rs
+++ b/src/to_lending/windows_mut.rs
@@ -1,4 +1,5 @@
 use crate::LendingIterator;
+use alloc::vec::Vec;
 
 /// A lending iterator over mutable windows.
 ///

--- a/src/traits/lending_iterator.rs
+++ b/src/traits/lending_iterator.rs
@@ -1,8 +1,8 @@
-use std::{num::NonZeroUsize, ops::Deref};
+use core::{num::NonZeroUsize, ops::Deref};
 
 use crate::{
     Chain, Cloned, Enumerate, Filter, FilterMap, Map, OptionTrait, SingleArgFnMut, SingleArgFnOnce,
-    Skip, StepBy, Take, Zip, TakeWhile,
+    Skip, StepBy, Take, TakeWhile, Zip,
 };
 
 /// Like [`Iterator`], but items may borrow from `&mut self`.
@@ -91,7 +91,7 @@ pub trait LendingIterator {
     fn take_while<P>(self, predicate: P) -> TakeWhile<Self, P>
     where
         Self: Sized,
-        P: for <'a> FnMut(&Self::Item<'a>) -> bool
+        P: for<'a> FnMut(&Self::Item<'a>) -> bool,
     {
         TakeWhile::new(self, predicate)
     }

--- a/src/traits/to_lending_iterator.rs
+++ b/src/traits/to_lending_iterator.rs
@@ -1,4 +1,6 @@
-use crate::{IntoLending, LendRefs, LendRefsMut, Windows, WindowsMut};
+use crate::{IntoLending, LendRefs, LendRefsMut};
+#[cfg(feature = "alloc")]
+use crate::{Windows, WindowsMut};
 
 /// An extension trait for iterators that allows turning them into lending iterators (over windows of elements).
 pub trait ToLendingIterator: IntoIterator {
@@ -8,6 +10,7 @@ pub trait ToLendingIterator: IntoIterator {
     /// This was chosen as a compromise between memory usage and time complexity:
     /// if the buffer was limited to size `size`, we would need to shift all the elements
     /// on every iteration.
+    #[cfg(feature = "alloc")]
     fn windows(self, size: usize) -> Windows<Self::IntoIter>
     where
         Self: Sized,
@@ -21,6 +24,7 @@ pub trait ToLendingIterator: IntoIterator {
     /// This was chosen as a compromise between memory usage and time complexity:
     /// if the buffer was limited to size `size`, we would need to shift all the elements
     /// on every iteration.
+    #[cfg(feature = "alloc")]
     fn windows_mut(self, size: usize) -> WindowsMut<Self::IntoIter>
     where
         Self: Sized,


### PR DESCRIPTION
Pull first couple easy changes from main [pr](https://github.com/Crazytieguy/gat-lending-iterator/pull/24).

Please discuss default features, I just made it empty out of habit, but it could be `["alloc"]` in order to make this not a breaking change.