### PR TITLE
Add comprehensive test suite (closes #5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Rust library implementing a lending iterator trait using Generic Associated Types (GATs). Lending iterators allow items to borrow from `&mut self`, which enables patterns like iterating over windows of elements with references that don't outlive the iterator.
+
+## Core Architecture
+
+**Main Trait**: `LendingIterator` (src/traits/lending_iterator.rs)
+- Uses GAT syntax: `type Item<'a> where Self: 'a`
+- Items can borrow from the iterator, enforced by the compiler
+- Methods mirror standard `Iterator` trait where applicable
+
+**Extension Trait**: `ToLendingIterator` (src/traits/to_lending_iterator.rs)
+- Implemented for all `IntoIterator` types
+- Converts regular iterators into lending iterators
+- Key methods: `windows()`, `windows_mut()`, `into_lending()`, `lend_refs()`, `lend_refs_mut()`
+
+**Adapters** (src/adapters/)
+- Each adapter type is in its own file
+- Some adapters conditionally implement `IntoIterator` when the returned type doesn't borrow from input (e.g., `Map`, `Cloned`)
+- Helper traits: `SingleArgFnMut`, `SingleArgFnOnce`, `OptionTrait` enable generic behavior over closures
+
+**Converters** (src/to_lending/)
+- Transform regular iterators into lending iterators
+- `Windows` and `WindowsMut` use a buffer that grows to at most size * 2 (tradeoff between memory and avoiding element shifting)
+
+## Development Commands
+
+**Build**: `cargo build --verbose`
+
+**Run all tests**: `cargo test --verbose`
+
+**Run specific test**: `cargo test <test_name>`
+
+**Run single test file**: Tests are in `src/lib.rs` under the `tests` module
+
+**Check documentation**: `cargo doc --open`
+
+## Design Constraints
+
+- Closure lifetime binders: On stable Rust, closures can't have lifetime-bound outputs tied to inputs. Use functions instead or nightly's `closure_lifetime_binder` feature.
+- Some `Iterator` methods don't make sense for `LendingIterator` (e.g., `collect`, `peekable`, `last`) because they require multiple items to be accessible simultaneously.
+- The `find()` and `find_map()` methods use unsafe pointer casting (polonius pattern) to work around current borrow checker limitations.
+- Quality is the most important consideration, only commit work you think maintains or improves the quality of the crate

--- a/src/adapters/chain.rs
+++ b/src/adapters/chain.rs
@@ -47,3 +47,26 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{LendingIterator, ToLendingIterator};
+
+    fn to_vec_i32(w: &[i32]) -> Vec<i32> {
+        w.to_vec()
+    }
+
+    #[test]
+    fn chain_basic() {
+        let result: Vec<_> = (0..3)
+            .windows(2)
+            .chain((5..8).windows(2))
+            .map(to_vec_i32)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![
+            vec![0, 1], vec![1, 2],
+            vec![5, 6], vec![6, 7]
+        ]);
+    }
+}

--- a/src/adapters/cloned.rs
+++ b/src/adapters/cloned.rs
@@ -66,3 +66,19 @@ where
         IntoIter { iter: self.iter }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{LendingIterator, ToLendingIterator};
+
+    #[test]
+    fn cloned_basic() {
+        let data = vec![1, 2, 3];
+        let result: Vec<_> = data
+            .lend_refs()
+            .cloned()
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![1, 2, 3]);
+    }
+}

--- a/src/adapters/enumerate.rs
+++ b/src/adapters/enumerate.rs
@@ -83,4 +83,13 @@ mod test {
         assert_eq!((second, second), (delay_iter.next(), delay_lending.next()));
         assert_eq!((None, None), (delay_iter.next(), delay_lending.next()));
     }
+
+    #[test]
+    fn enumerate_basic() {
+        let mut iter = (10..13).into_lending().enumerate();
+        assert_eq!(iter.next(), Some((0, 10)));
+        assert_eq!(iter.next(), Some((1, 11)));
+        assert_eq!(iter.next(), Some((2, 12)));
+        assert_eq!(iter.next(), None);
+    }
 }

--- a/src/adapters/filter.rs
+++ b/src/adapters/filter.rs
@@ -51,3 +51,23 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{LendingIterator, ToLendingIterator};
+
+    fn identity(x: i32) -> i32 {
+        x
+    }
+
+    #[test]
+    fn filter_basic() {
+        let result: Vec<_> = (0..10)
+            .into_lending()
+            .filter(|&x| x % 2 == 0)
+            .map(identity)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![0, 2, 4, 6, 8]);
+    }
+}

--- a/src/adapters/filter_map.rs
+++ b/src/adapters/filter_map.rs
@@ -55,3 +55,26 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{LendingIterator, ToLendingIterator};
+
+    fn positive_double(x: i32) -> Option<i32> {
+        if x >= 0 {
+            Some(x * 2)
+        } else {
+            None
+        }
+    }
+
+    #[test]
+    fn filter_map_basic() {
+        let mut result = Vec::new();
+        vec![-1, 2, -3, 4]
+            .into_lending()
+            .filter_map(positive_double)
+            .for_each(|x| result.push(x));
+        assert_eq!(result, vec![4, 8]);
+    }
+}

--- a/src/adapters/map.rs
+++ b/src/adapters/map.rs
@@ -77,3 +77,37 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{LendingIterator, ToLendingIterator};
+
+    fn double(x: i32) -> i32 {
+        x * 2
+    }
+
+    fn extract_second(slice: &[i32]) -> &i32 {
+        &slice[1]
+    }
+
+    #[test]
+    fn map_basic() {
+        let result: Vec<_> = (0..3)
+            .into_lending()
+            .map(double)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![0, 2, 4]);
+    }
+
+    #[test]
+    fn map_with_borrowing() {
+        let result: Vec<_> = (0..5)
+            .windows(3)
+            .map(extract_second)
+            .cloned()
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![1, 2, 3]);
+    }
+}

--- a/src/adapters/skip.rs
+++ b/src/adapters/skip.rs
@@ -41,10 +41,36 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::ToLendingIterator;
+    use crate::{LendingIterator, ToLendingIterator};
+
+    fn identity(x: i32) -> i32 {
+        x
+    }
+
     #[test]
     fn test() {
         assert_eq!((0..5).into_lending().skip(1).nth(1), (0..5).skip(1).nth(1));
+    }
+
+    #[test]
+    fn skip_basic() {
+        let result: Vec<_> = (0..5)
+            .into_lending()
+            .skip(2)
+            .map(identity)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![2, 3, 4]);
+    }
+
+    #[test]
+    fn skip_more_than_available() {
+        let result: Vec<_> = (0..3)
+            .into_lending()
+            .skip(10)
+            .map(identity)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![]);
     }
 }

--- a/src/adapters/skip_while.rs
+++ b/src/adapters/skip_while.rs
@@ -64,3 +64,23 @@ where
     // TODO: there's a `fold` optimization possible here,
     // but for some reason the lifetimes don't type check
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{LendingIterator, ToLendingIterator};
+
+    fn identity(x: i32) -> i32 {
+        x
+    }
+
+    #[test]
+    fn skip_while_basic() {
+        let result: Vec<_> = (0..10)
+            .into_lending()
+            .skip_while(|&x| x < 5)
+            .map(identity)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![5, 6, 7, 8, 9]);
+    }
+}

--- a/src/adapters/step_by.rs
+++ b/src/adapters/step_by.rs
@@ -46,3 +46,23 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{LendingIterator, ToLendingIterator};
+
+    fn identity(x: i32) -> i32 {
+        x
+    }
+
+    #[test]
+    fn step_by_basic() {
+        let result: Vec<_> = (0..10)
+            .into_lending()
+            .step_by(3)
+            .map(identity)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![0, 3, 6, 9]);
+    }
+}

--- a/src/adapters/take.rs
+++ b/src/adapters/take.rs
@@ -37,8 +37,12 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::ToLendingIterator;
+    use crate::{LendingIterator, ToLendingIterator};
+
+    fn identity(x: i32) -> i32 {
+        x
+    }
+
     #[test]
     fn test() {
         assert_eq!(
@@ -48,5 +52,27 @@ mod test {
                 .fold(0, |count, ()| { count + 1 }),
             5
         );
+    }
+
+    #[test]
+    fn take_basic() {
+        let result: Vec<_> = (0..10)
+            .into_lending()
+            .take(3)
+            .map(identity)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn take_more_than_available() {
+        let result: Vec<_> = (0..3)
+            .into_lending()
+            .take(10)
+            .map(identity)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![0, 1, 2]);
     }
 }

--- a/src/adapters/take_while.rs
+++ b/src/adapters/take_while.rs
@@ -62,3 +62,23 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{LendingIterator, ToLendingIterator};
+
+    fn identity(x: i32) -> i32 {
+        x
+    }
+
+    #[test]
+    fn take_while_basic() {
+        let result: Vec<_> = (0..10)
+            .into_lending()
+            .take_while(|&x| x < 5)
+            .map(identity)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![0, 1, 2, 3, 4]);
+    }
+}

--- a/src/adapters/zip.rs
+++ b/src/adapters/zip.rs
@@ -36,3 +36,34 @@ where
         Some((a, b))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{LendingIterator, ToLendingIterator};
+
+    fn make_pair(pair: (i32, i32)) -> (i32, i32) {
+        pair
+    }
+
+    #[test]
+    fn zip_basic() {
+        let result: Vec<_> = (0..3)
+            .into_lending()
+            .zip((10..13).into_lending())
+            .map(make_pair)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![(0, 10), (1, 11), (2, 12)]);
+    }
+
+    #[test]
+    fn zip_unequal_lengths() {
+        let result: Vec<_> = (0..5)
+            .into_lending()
+            .zip((10..12).into_lending())
+            .map(make_pair)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![(0, 10), (1, 11)]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,45 +93,235 @@ pub use self::traits::*;
 mod tests {
     use super::*;
 
-    fn second(slice: &[usize]) -> &usize {
+    #[test]
+    fn count_basic() {
+        assert_eq!((0..5).windows(2).count(), 4);
+        assert_eq!((0..3).into_lending().count(), 3);
+        assert_eq!(std::iter::empty::<i32>().into_lending().count(), 0);
+    }
+
+    #[test]
+    fn nth_basic() {
+        let mut iter = (0..5).windows(2);
+        assert_eq!(iter.nth(0), Some(&[0, 1][..]));
+        assert_eq!(iter.nth(1), Some(&[2, 3][..]));
+        assert_eq!(iter.nth(0), Some(&[3, 4][..]));
+        assert_eq!(iter.nth(0), None);
+    }
+
+    #[test]
+    fn nth_out_of_bounds() {
+        let mut iter = (0..3).into_lending();
+        assert_eq!(iter.nth(10), None);
+    }
+
+    #[test]
+    fn advance_by_basic() {
+        let mut iter = (0..5).into_lending();
+        assert_eq!(iter.advance_by(2), Ok(()));
+        assert_eq!(iter.next(), Some(2));
+    }
+
+    #[test]
+    fn advance_by_too_far() {
+        let mut iter = (0..3).into_lending();
+        assert!(iter.advance_by(10).is_err());
+    }
+
+    #[test]
+    fn for_each_basic() {
+        let mut sum = 0;
+        (1..=5).into_lending().for_each(|x| sum += x);
+        assert_eq!(sum, 15);
+    }
+
+    #[test]
+    fn fold_basic() {
+        let sum = (1..=5).into_lending().fold(0, |acc, x| acc + x);
+        assert_eq!(sum, 15);
+    }
+
+    #[test]
+    fn fold_product() {
+        let product = (1..=5).into_lending().fold(1, |acc, x| acc * x);
+        assert_eq!(product, 120);
+    }
+
+    #[test]
+    fn all_true() {
+        assert!((0..5).into_lending().all(|x| x < 10));
+    }
+
+    #[test]
+    fn all_false() {
+        assert!(!(0..5).into_lending().all(|x| x < 3));
+    }
+
+    #[test]
+    fn all_empty() {
+        assert!(std::iter::empty::<i32>().into_lending().all(|_| false));
+    }
+
+    #[test]
+    fn any_true() {
+        assert!((0..5).into_lending().any(|x| x == 3));
+    }
+
+    #[test]
+    fn any_false() {
+        assert!(!(0..5).into_lending().any(|x| x > 10));
+    }
+
+    #[test]
+    fn any_empty() {
+        assert!(!std::iter::empty::<i32>().into_lending().any(|_| true));
+    }
+
+    #[test]
+    fn is_partitioned_true() {
+        assert!(vec![2, 4, 6, 1, 3, 5].into_lending().is_partitioned(|x| x % 2 == 0));
+    }
+
+    #[test]
+    fn is_partitioned_false() {
+        assert!(!vec![2, 1, 4, 3].into_lending().is_partitioned(|x| x % 2 == 0));
+    }
+
+    #[test]
+    fn find_found() {
+        let mut iter = (0..5).into_lending();
+        assert_eq!(iter.find(|x| *x == 3), Some(3));
+    }
+
+    #[test]
+    fn find_not_found() {
+        let mut iter = (0..5).into_lending();
+        assert_eq!(iter.find(|x| *x == 10), None);
+    }
+
+    #[test]
+    fn find_map_found() {
+        let mut iter = vec![1, -2, 3, -4].into_lending();
+        let result = iter.find_map(|x| if x < 0 { Some(-x) } else { None });
+        assert_eq!(result, Some(2));
+    }
+
+    #[test]
+    fn find_map_not_found() {
+        let mut iter = vec![1, 2, 3].into_lending();
+        let result = iter.find_map(|x| if x < 0 { Some(-x) } else { None });
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn position_found() {
+        let mut iter = (0..5).into_lending();
+        assert_eq!(iter.position(|x| x == 3), Some(3));
+    }
+
+    #[test]
+    fn position_not_found() {
+        let mut iter = (0..5).into_lending();
+        assert_eq!(iter.position(|x| x == 10), None);
+    }
+
+    #[test]
+    fn cmp_equal() {
+        use std::cmp::Ordering;
+        let result = (0i32..3).into_lending().cmp((0i32..3).into_lending());
+        assert_eq!(result, Ordering::Equal);
+    }
+
+    #[test]
+    fn cmp_less() {
+        use std::cmp::Ordering;
+        let result = (0i32..3).into_lending().cmp((0i32..5).into_lending());
+        assert_eq!(result, Ordering::Less);
+    }
+
+    #[test]
+    fn cmp_greater() {
+        use std::cmp::Ordering;
+        let result = (0i32..5).into_lending().cmp((0i32..3).into_lending());
+        assert_eq!(result, Ordering::Greater);
+    }
+
+    #[test]
+    fn cmp_by_basic() {
+        use std::cmp::Ordering;
+        let result = (0i32..3).into_lending().cmp_by((0i32..3).into_lending(), |a, b| a.cmp(&b));
+        assert_eq!(result, Ordering::Equal);
+    }
+
+    #[test]
+    fn partial_cmp_by_basic() {
+        use std::cmp::Ordering;
+        let result = (0i32..3).into_lending().partial_cmp_by((0i32..3).into_lending(), |a, b| a.partial_cmp(&b));
+        assert_eq!(result, Some(Ordering::Equal));
+    }
+
+    #[test]
+    fn eq_by_basic() {
+        assert!((0i32..3).into_lending().eq_by((0i32..3).into_lending(), |a, b| a == b));
+    }
+
+    #[test]
+    fn eq_by_false() {
+        assert!(!(0i32..3).into_lending().eq_by((1i32..4).into_lending(), |a, b| a == b));
+    }
+
+    #[test]
+    fn size_hint_basic() {
+        let iter = (0..5).into_lending();
+        assert_eq!(iter.size_hint(), (5, Some(5)));
+    }
+
+    fn to_vec_i32(w: &[i32]) -> Vec<i32> {
+        w.to_vec()
+    }
+
+    #[test]
+    fn complex_chain_windows_filter() {
+        let result: Vec<_> = (0..5)
+            .windows(3)
+            .filter(|x| x[0] % 2 == 0)
+            .chain((0..6).windows(2))
+            .map(to_vec_i32)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![
+            vec![0, 1, 2], vec![2, 3, 4],
+            vec![0, 1], vec![1, 2], vec![2, 3], vec![3, 4], vec![4, 5]
+        ]);
+    }
+
+    fn accumulate_window_usize(slice: &mut [usize]) -> usize {
+        slice[1] += slice[0];
+        slice[1]
+    }
+
+    #[test]
+    fn complex_windows_mut_map() {
+        let result: Vec<_> = (0..7)
+            .windows_mut(2)
+            .map(accumulate_window_usize)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![1, 3, 6, 10, 15, 21]);
+    }
+
+    fn second_usize(slice: &[usize]) -> &usize {
         &slice[1]
     }
 
     #[test]
-    fn playground() {
-        (0..5)
+    fn complex_windows_map_cloned() {
+        let result: Vec<_> = (0..5)
             .windows(3)
-            .filter(|x| x[0] % 2 == 0)
-            .chain((0..6).windows(2))
-            .for_each(|x| println!("{x:?}"));
-
-        println!();
-
-        for sum in (0..7).windows_mut(2).map(|slice: &mut [usize]| {
-            slice[1] += slice[0];
-            slice[1]
-        }) {
-            println!("{sum}");
-        }
-
-        println!();
-
-        for n in (0..5).windows(3).map(second).cloned() {
-            println!("{n}");
-        }
-
-        println!();
-
-        (0..5)
-            .windows(4)
-            .zip([0, 1].into_lending())
-            .for_each(|(a, b)| {
-                println!("{a:?}, {b:?}");
-            });
-        
-        (0..5)
-            .windows(2)
-            .skip_while(|w| w[0] < 2)
-            .fold(0, |acc, x| acc + x[1]);
+            .map(second_usize)
+            .cloned()
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![1, 2, 3]);
     }
 }

--- a/src/to_lending/into_lending.rs
+++ b/src/to_lending/into_lending.rs
@@ -23,3 +23,22 @@ impl<I: Iterator> LendingIterator for IntoLending<I> {
         self.iter.size_hint()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{LendingIterator, ToLendingIterator};
+
+    fn double_i32(x: i32) -> i32 {
+        x * 2
+    }
+
+    #[test]
+    fn into_lending_basic() {
+        let result: Vec<_> = vec![1, 2, 3]
+            .into_lending()
+            .map(double_i32)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![2, 4, 6]);
+    }
+}

--- a/src/to_lending/lend_refs.rs
+++ b/src/to_lending/lend_refs.rs
@@ -53,4 +53,18 @@ mod test {
         let w = W { x: Foo(0) };
         std::iter::once(Foo(0)).lend_refs().chain(w)
     }
+
+    fn double_ref_i32(x: &i32) -> i32 {
+        x * 2
+    }
+
+    #[test]
+    fn lend_refs_basic() {
+        let result: Vec<_> = vec![1, 2, 3]
+            .lend_refs()
+            .map(double_ref_i32)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![2, 4, 6]);
+    }
 }

--- a/src/to_lending/lend_refs_mut.rs
+++ b/src/to_lending/lend_refs_mut.rs
@@ -54,4 +54,14 @@ mod test {
         let w = W { x: Foo(0) };
         std::iter::once(Foo(0)).lend_refs_mut().chain(w)
     }
+
+    #[test]
+    fn lend_refs_mut_basic() {
+        let mut sum = 0;
+        vec![1, 2, 3].lend_refs_mut().for_each(|x| {
+            *x *= 2;
+            sum += *x;
+        });
+        assert_eq!(sum, 12);
+    }
 }

--- a/src/to_lending/windows.rs
+++ b/src/to_lending/windows.rs
@@ -37,3 +37,44 @@ impl<I: Iterator> LendingIterator for Windows<I> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{LendingIterator, ToLendingIterator};
+
+    fn to_vec_i32(w: &[i32]) -> Vec<i32> {
+        w.to_vec()
+    }
+
+    #[test]
+    fn windows_basic() {
+        let result: Vec<_> = (0..5)
+            .windows(3)
+            .map(to_vec_i32)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![vec![0, 1, 2], vec![1, 2, 3], vec![2, 3, 4]]);
+    }
+
+    #[test]
+    fn windows_size_one() {
+        let result: Vec<_> = (0..3)
+            .windows(1)
+            .map(to_vec_i32)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![vec![0], vec![1], vec![2]]);
+    }
+
+    #[test]
+    fn windows_larger_than_iterator() {
+        let mut iter = (0..3).windows(5);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn windows_empty_iterator() {
+        let mut iter = std::iter::empty::<i32>().windows(3);
+        assert_eq!(iter.next(), None);
+    }
+}

--- a/src/to_lending/windows_mut.rs
+++ b/src/to_lending/windows_mut.rs
@@ -38,3 +38,33 @@ impl<I: Iterator> LendingIterator for WindowsMut<I> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{LendingIterator, ToLendingIterator};
+
+    fn accumulate_window(w: &mut [i32]) -> i32 {
+        w[1] += w[0];
+        w[1]
+    }
+
+    #[test]
+    fn windows_mut_basic() {
+        let result: Vec<_> = (0..5)
+            .windows_mut(2)
+            .map(accumulate_window)
+            .into_iter()
+            .collect();
+        assert_eq!(result, vec![1, 3, 6, 10]);
+    }
+
+    #[test]
+    fn windows_mut_modifies_elements() {
+        let mut sum = 0;
+        (0..4).windows_mut(2).for_each(|w| {
+            w[0] = w[0] * 2;
+            sum += w[0];
+        });
+        assert_eq!(sum, 6);
+    }
+}


### PR DESCRIPTION
## Summary

Adds 63 comprehensive tests covering the entire public API of the lending iterator crate. Tests are organized following the existing codebase pattern: tests live in their respective module files, with core trait and integration tests in `lib.rs`.

## Test Organization

**Tests in module files:**
- `src/to_lending/windows.rs` - 4 tests for window iteration
- `src/to_lending/windows_mut.rs` - 2 tests for mutable window iteration  
- `src/to_lending/into_lending.rs` - 1 test for iterator conversion
- `src/to_lending/lend_refs.rs` - 2 tests (1 existing + 1 new)
- `src/to_lending/lend_refs_mut.rs` - 2 tests (1 existing + 1 new)
- `src/adapters/step_by.rs` - 1 test
- `src/adapters/take.rs` - 3 tests (1 existing + 2 new)
- `src/adapters/take_while.rs` - 1 test
- `src/adapters/chain.rs` - 1 test
- `src/adapters/zip.rs` - 2 tests
- `src/adapters/map.rs` - 2 tests
- `src/adapters/filter.rs` - 1 test
- `src/adapters/filter_map.rs` - 1 test
- `src/adapters/cloned.rs` - 1 test
- `src/adapters/enumerate.rs` - 2 tests (1 existing + 1 new)
- `src/adapters/skip.rs` - 3 tests (1 existing + 2 new)
- `src/adapters/skip_while.rs` - 1 test

**Tests in `src/lib.rs` (28 tests):**
- Core trait methods: `count`, `nth`, `advance_by`, `for_each`, `fold`
- Search/predicate methods: `all`, `any`, `is_partitioned`, `find`, `find_map`, `position`
- Comparison methods: `cmp`, `cmp_by`, `partial_cmp_by`, `eq_by`
- Utilities: `size_hint`
- **3 complex integration tests** demonstrating real-world usage patterns

## Test Coverage Highlights

✅ **Basic functionality** - All major public methods tested  
✅ **Edge cases** - Empty iterators, out of bounds, size mismatches  
✅ **Type conversions** - Tests for `IntoIterator` implementations  
✅ **Borrowing patterns** - Tests showing lifetime-dependent returns  
✅ **Integration** - Complex chains of operations

## Design Notes

- Used functions instead of closures where needed to work around GAT borrow checker limitations (as documented in CLAUDE.md)
- Some comparison methods (`lt`, `le`, `gt`, `ge`, `eq`, `ne`, `partial_cmp`) omitted due to current trait solver limitations with lending iterators
- All tests use proper assertions rather than println statements
- Tests follow the existing pattern: module tests near implementation, integration tests in `lib.rs`

## Test Results

```
running 63 tests
test result: ok. 63 passed; 0 failed; 0 ignored
```

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)